### PR TITLE
Use configurable issuer domain in did doc

### DIFF
--- a/packages/server/src/api/__tests__/diddoc.test.js
+++ b/packages/server/src/api/__tests__/diddoc.test.js
@@ -1,0 +1,37 @@
+const DidDocumentHandler = require('../diddoc')
+
+describe('DidDocumentHandler', () => {
+  let sut
+  let claimMgrMock = { getPublicKeyHex: jest.fn(), getIssuerDomain: jest.fn() }
+
+  beforeAll(() => {
+    sut = new DidDocumentHandler(claimMgrMock)
+  })
+
+  test('empty constructor', () => {
+    expect(sut).not.toBeUndefined()
+  })
+
+  test('happy path', done => {
+    claimMgrMock.getPublicKeyHex.mockReturnValue('0x1')
+    claimMgrMock.getIssuerDomain.mockReturnValue('example.com')
+
+    sut.handle(
+      {
+        headers: { origin: 'https://subdomain.3box.io' }
+      },
+      {},
+      (err, res) => {
+        expect(err).toBeNull()
+        expect(res.id).toEqual('did:web:example.com')
+        expect(res.publicKey[0].publicKeyHex).toEqual('0x1')
+        expect(res.publicKey[0].id).toEqual('did:web:example.com#owner')
+        expect(res.publicKey[0].owner).toEqual('did:web:example.com')
+        expect(res.authentication[0].publicKey).toEqual(
+          'did:web:example.com#owner'
+        )
+        done()
+      }
+    )
+  })
+})

--- a/packages/server/src/api/diddoc.js
+++ b/packages/server/src/api/diddoc.js
@@ -6,22 +6,23 @@ class DidDocumentHandler {
 
   async handle(event, context, cb) {
     let publicKeyHex = this.claimMgr.getPublicKeyHex()
+    let issuerDomain = this.claimMgr.getIssuerDomain()
 
     let body = {
       '@context': 'https://w3id.org/did/v1',
-      id: 'did:web:verifications.3boxlabs.com',
+      id: `did:web:${issuerDomain}`,
       publicKey: [
         {
-          id: 'did:web:verifications.3boxlabs.com#owner',
+          id: `did:web:${issuerDomain}#owner`,
           type: 'Secp256k1VerificationKey2018',
-          owner: 'did:web:verifications.3boxlabs.com',
+          owner: `did:web:${issuerDomain}`,
           publicKeyHex: publicKeyHex
         }
       ],
       authentication: [
         {
           type: 'Secp256k1SignatureAuthentication2018',
-          publicKey: 'did:web:verifications.3boxlabs.com#owner'
+          publicKey: `did:web:${issuerDomain}#owner`
         }
       ]
     }

--- a/packages/server/src/lib/claimMgr.js
+++ b/packages/server/src/lib/claimMgr.js
@@ -33,7 +33,7 @@ class ClaimMgr {
     this.resolver = {
       registry: {
         ...KeyResolver.getResolver(),
-        ...ThreeIdResolver.getResolver(ceramic),
+        ...ThreeIdResolver.getResolver(ceramic)
       }
     }
   }
@@ -86,6 +86,11 @@ class ClaimMgr {
     return this.signerPublic
   }
 
+  getIssuerDomain() {
+    if (!this.issuerDomain) throw new Error('no keypair created yet')
+    return this.issuerDomain
+  }
+
   async verifyToken(token) {
     if (!token) throw new Error('no token')
     return didJWT.verifyJWT(token, { resolver: this.resolver })
@@ -94,7 +99,7 @@ class ClaimMgr {
   async verifyJWS(jws) {
     if (!jws) throw new Error('no jws')
     const did = new DID({
-      resolver: this.resolver.registry,
+      resolver: this.resolver.registry
     })
     const { kid, payload } = await did.verifyJWS(jws)
     return { kid, payload, did: kid.split(/[#?]/)[0] }


### PR DESCRIPTION
I believe this is what is intended. The issuer domain defined as `VERIFICATION_ISSUER_DOMAIN` should be the issuer domain returned in the DID document.